### PR TITLE
Fix/secondary priors tweak

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+1.0.3 (2021-05-14)
+------------------
+- Another small tweak to secondary priors: ensure 1/M if a given prior is not set.
+
 1.0.2 (2021-05-13)
 ------------------
 - Fixed a memory leak when fitting multiple companions, fixed prior on secondary masses to fully undo a 1/M prior.

--- a/orvara/main.py
+++ b/orvara/main.py
@@ -204,7 +204,9 @@ def lnprob(theta, returninfo=False, RVoffsets=False, use_epoch_astrometry=False,
         orbit.calc_offsets(data, params, model, i)
 
         if priors is not None:
-            lnp = lnp - 0.5*(params.msec - priors.get(f'm_secondary{i}', 1))**2/priors.get(f'm_secondary{i}_sig', np.inf)**2 + np.log(params.msec)
+            chisq_sec = (params.msec - priors.get(f'm_secondary{i}', 1))**2/priors.get(f'm_secondary{i}_sig', np.inf)**2
+            if chisq_sec > 0:
+                lnp = lnp - 0.5*chisq_sec + np.log(params.msec)
 
         # Free params if we need to cycle through the next companion
         if i < nplanets - 1:

--- a/orvara/main.py
+++ b/orvara/main.py
@@ -221,11 +221,10 @@ def lnprob(theta, returninfo=False, RVoffsets=False, use_epoch_astrometry=False,
     if returninfo:
         return orbit.calcL(data, params, model, chisq_resids=True, RVoffsets=RVoffsets)
 
-    if priors is not None:
-        if np.isfinite(priors['mpri_sig']):
-            return lnp - 0.5*(params.mpri_true - priors['mpri'])**2/priors['mpri_sig']**2 + orbit.calcL(data, params, model)
-
-    return lnp - np.log(params.mpri_true) + orbit.calcL(data, params, model)
+    if np.isfinite(priors['mpri_sig']):
+        return lnp - 0.5*(params.mpri_true - priors['mpri'])**2/priors['mpri_sig']**2 + orbit.calcL(data, params, model)
+    else:
+        return lnp - np.log(params.mpri_true) + orbit.calcL(data, params, model)
 
     
 def return_one(theta):

--- a/orvara/main.py
+++ b/orvara/main.py
@@ -203,10 +203,11 @@ def lnprob(theta, returninfo=False, RVoffsets=False, use_epoch_astrometry=False,
         orbit.calc_RV(data, params, model)
         orbit.calc_offsets(data, params, model, i)
 
-        if priors is not None:
-            chisq_sec = (params.msec - priors.get(f'm_secondary{i}', 1))**2/priors.get(f'm_secondary{i}_sig', np.inf)**2
-            if chisq_sec > 0:
-                lnp = lnp - 0.5*chisq_sec + np.log(params.msec)
+        chisq_sec = (params.msec - priors[f'm_secondary{i}'])**2/priors[f'm_secondary{i}_sig']**2
+        if chisq_sec > 0:  # If chisq_sec > 0 then a prior was set on the mass of the secondary
+            # undo the default 1/m prior that is set in orbit.pyx (see lnprior())
+            lnp = lnp - 0.5*chisq_sec + np.log(params.msec)
+        # else, don't change lnp at all.
 
         # Free params if we need to cycle through the next companion
         if i < nplanets - 1:

--- a/orvara/tests/config_with_secondary_priors.ini
+++ b/orvara/tests/config_with_secondary_priors.ini
@@ -35,9 +35,9 @@ nthreads = 2
 use_epoch_astrometry = True
 
 [priors_settings]
-# Priors on 1th companion (companion labelled 1 in your input data files)
-m_secondary1 = 1
-m_secondary1_sig = 2
+# Priors on 0th companion (companion labelled 0 in your input data files)
+m_secondary0 = 1
+m_secondary0_sig = 2
 
 # Priors on 7th companion (companion labelled 7 in your input data files)
 m_secondary7 = 3

--- a/orvara/tests/test_main.py
+++ b/orvara/tests/test_main.py
@@ -22,8 +22,8 @@ def test_get_priors():
     config = ConfigParser()
     config.read('orvara/tests/config_with_secondary_priors.ini')
     priors = get_priors(config)
-    assert priors['m_secondary1'] == 1
-    assert priors['m_secondary1_sig'] == 2
+    assert priors['m_secondary0'] == 1
+    assert priors['m_secondary0_sig'] == 2
     assert priors['m_secondary7'] == 3
     assert priors['m_secondary7_sig'] == 4
 

--- a/orvara/tests/test_main.py
+++ b/orvara/tests/test_main.py
@@ -36,6 +36,15 @@ def test_run(fake_args):
         run()
         assert True
 
+
+@pytest.mark.integration
+@mock.patch('orvara.main.parse_args')
+def test_run_with_secondary_priors(fake_args):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        fake_args.return_value = FakeArguments('orvara/tests/config_with_secondary_priors.ini', tmp_dir)
+        run()
+        assert True
+
 @pytest.mark.e2e
 @mock.patch('orvara.main.parse_args')
 def test_converges_to_accurate_values(fake_args):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ modules = [Extension("orvara.orbit", source_files, extra_compile_args=['-O3'])]
 
 setup(name='orvara',
       ext_modules=cythonize(modules),
-      version='1.0.2',
+      version='1.0.3',
       python_requires='>=3.5',
       package_dir={'orvara': 'orvara'},
       install_requires=['numpy>=1.13', 'htof>=0.3.4', 'emcee', 'ptemcee',


### PR DESCRIPTION
In the last iteration I undid the 1/M secondary mass prior if the priors object was set.  Now I undo it only if a given secondary mass prior is set with finite variance.