### PR TITLE
Feature/dev utils timing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+1.0.5 (2021-05-14)
+------------------
+- Added a dev_utils module and a script for timing the RV calculations.
+
 1.0.4 (2021-05-14)
 ------------------
 - Fixed units bug in periastron time calculation.

--- a/orvara/dev_utils/timing.py
+++ b/orvara/dev_utils/timing.py
@@ -1,0 +1,30 @@
+from orvara import orbit
+import numpy as np
+import time
+
+
+def random_rv_data_params_model(Nsamples):
+    jit, mpri, msec, sau = 0.5, 1, 0.1, 10
+    esino, ecoso, inc, asc, lam = 0.5, 0.5, 1, 1, 1
+    data = orbit.Data(27321, 'None', 'None', 'None')
+    data.custom_epochs(list(np.linspace(data.refep, data.refep+1000, Nsamples)))
+    model = orbit.Model(data)
+    theta = np.array([jit, mpri, msec, sau, esino, ecoso, inc, asc, lam])
+    params = orbit.Params(theta, 0, 1, data.nInst, 1)
+    orbit.calc_EA_RPP(data, params, model)
+    return data, params, model
+
+
+def time_calc_rv(Nsamples, loops):
+    data, params, model = random_rv_data_params_model(Nsamples=int(Nsamples))
+
+    times = []
+    for i in range(int(loops)):
+        t = time.time_ns()
+        orbit.calc_RV(data, params, model)
+        times.append(time.time_ns() - t)
+    return np.mean(times)/Nsamples, '+-', np.std(times)/np.sqrt(loops), 'nano seconds per eval'
+
+
+if __name__ == "__main__":
+    print(time_calc_rv(1E2, 1E5))

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ modules = [Extension("orvara.orbit", source_files, extra_compile_args=['-O3'])]
 
 setup(name='orvara',
       ext_modules=cythonize(modules),
-      version='1.0.4',
+      version='1.0.5',
       python_requires='>=3.5',
       package_dir={'orvara': 'orvara'},
       install_requires=['numpy>=1.13', 'htof>=0.3.4', 'emcee', 'ptemcee',


### PR DESCRIPTION
This PR adds a small dev_utils folder. For now, it just contains a timing test for the RV calculation. This facilitates easy performance assessments of future additions to the code (e.g., feature/relative_rv_new)