### PR TITLE
Feature/fit relative rv

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,25 @@ Note: We recommend starting with ``use_epoch_astrometry = False``. If this
 fails, then there is something wrong with the RVFile, HGCAFile, or (relative)
 AstrometryFile. If that chain finishes fine, then set ``use_epoch_astrometry = True``.
 
+Relative RV fitting
+~~~~~~~~~~~~~~~~~~~
+For stellar binaries, if the relative velocities of both the primary the and
+secondary star have been directly measured, the relative velocity of the system
+can be included as an additional orbit fitting constraint. Relative RV values
+are RV_B - RV_A (i.e. secondary star radial velocity - primary star radial
+velocity). Measured relative RVs are input in a file which can have one or more
+relative RV measurements. The file with relative RVs should have three columns
+corresponding to epoch, relative_RV and relative_RV_error and
+should be included in the ``[data_paths]`` field of the config file as
+``RelativeRVFile = /path/to/relativervfile.dat``
+
+Note that this feature is currently only set up for a two-body system; a
+possible future improvement would be to equate relative RV values with specific
+companions, as is done for relative astrometry values.
+
+This feature is not currently tested by the ``pytest -sv`` suite of tests,
+and there is currently no example config file for a fit using the relative RV.
+
 Setting priors
 ~~~~~~~~~~~~~~
 Adding Gaussian mass priors are supported. As well, bounded log-uniform priors

--- a/orvara/main.py
+++ b/orvara/main.py
@@ -121,12 +121,14 @@ def initialize_data(config, companion_gaia):
 
     RVFile = config.get('data_paths', 'RVFile', fallback='')
     AstrometryFile = config.get('data_paths', 'AstrometryFile', fallback='')
+    RelativeRVFile = config.get('data_paths', 'RelativeRVFile', fallback='')
     GaiaDataDir = config.get('data_paths', 'GaiaDataDir', fallback='')
     Hip2DataDir = config.get('data_paths', 'Hip2DataDir', fallback='')
     Hip1DataDir = config.get('data_paths', 'Hip1DataDir', fallback='')
     use_epoch_astrometry = config.getboolean('mcmc_settings', 'use_epoch_astrometry', fallback=False)
 
-    data = orbit.Data(HipID, HGCAFile, RVFile, AstrometryFile, companion_gaia=companion_gaia)
+    data = orbit.Data(HipID, HGCAFile, RVFile, AstrometryFile, RelativeRVFile, 
+                      companion_gaia=companion_gaia)
     if use_epoch_astrometry and data.use_abs_ast == 1:
         # TODO verify that this half-day should indeed be here. This doesnt matter for ~10 year orbits,
         #  but would matter if we wanted to fit companions with shorter orbital arcs.
@@ -149,7 +151,7 @@ def initialize_data(config, companion_gaia):
         hip2_fast_fitter = orbit.AstrometricFitter(Hip2_fitter)
         gaia_fast_fitter = orbit.AstrometricFitter(Gaia_fitter)
 
-        data = orbit.Data(HipID, HGCAFile, RVFile, AstrometryFile, 
+        data = orbit.Data(HipID, HGCAFile, RVFile, AstrometryFile, RelativeRVFile,
                           use_epoch_astrometry,
                           epochs_Hip1=Hip1_fitter.data.julian_day_epoch(),
                           epochs_Hip2=Hip2_fitter.data.julian_day_epoch(),

--- a/orvara/main_plotting.py
+++ b/orvara/main_plotting.py
@@ -51,6 +51,7 @@ def initialize_plot_options(config):
     # read data
     OP.RVfile = config.get('data_paths', 'RVFile', fallback=None)
     OP.relAstfile = config.get('data_paths', 'AstrometryFile', fallback=None)
+    OP.relRVfile = config.get('data_paths', 'RelativeRVFile', fallback=None)
     OP.GaiaDataDir = config.get('data_paths', 'GaiaDataDir', fallback=None)
     OP.Hip2DataDir = config.get('data_paths', 'Hip2DataDir', fallback=None)
     OP.Hip1DataDir = config.get('data_paths', 'Hip1DataDir', fallback=None)

--- a/orvara/orbit.pyx
+++ b/orvara/orbit.pyx
@@ -115,6 +115,8 @@ cdef class Data:
     cdef double [:] epochs
     cdef double [:] RV
     cdef double [:] RV_err
+    cdef double [:] relRV
+    cdef double [:] relRV_err
     cdef int [:] RVinst
     cdef double [:] relsep
     cdef double [:] PA
@@ -122,7 +124,7 @@ cdef class Data:
     cdef double [:] PA_err
     cdef double [:] relsep_pa_corr
     cdef int [:] ast_planetID
-    cdef public int nRV, nAst, nHip1, nHip2, nGaia, nTot, nInst, companion_ID
+    cdef public int nRV, nAst, nrelRV, nHip1, nHip2, nGaia, nTot, nInst, companion_ID
     cdef public double pmra_H, pmdec_H, pmra_HG, pmdec_HG, pmra_G, pmdec_G
     cdef public double pmra_G_B, pmdec_G_B
     cdef public double plx, plx_err
@@ -134,7 +136,7 @@ cdef class Data:
     cdef public double epRA_H, epDec_H, epRA_G, epDec_G, dt_H, dt_G
     cdef public int use_abs_ast
 
-    def __init__(self, Hip, HGCAfile, RVfile, relAstfile,
+    def __init__(self, Hip, HGCAfile, RVfile, relAstfile, relRVfile,
                  use_epoch_astrometry=False,
                  epochs_Hip1=None, epochs_Hip2=None, epochs_Gaia=None,
                  refep=2455197.5000, companion_gaia=None, verbose=True):
@@ -166,6 +168,22 @@ cdef class Data:
                     print("Assuming all data are from one instrument.")
                 self.RVinst = (rvdat[:, 2]*0).astype(np.int32)
                 self.nInst = 1
+
+        ##################################
+        try:
+            relRVdat = np.genfromtxt(relRVfile)
+            if np.ndim(relRVdat) == 1:
+                relRVdat = np.reshape(relRVdat, (1,relRVdat.size))
+            self.relRV = relRVdat[:, 1]
+            self.relRV_err = relRVdat[:, 2]
+            self.nrelRV = relRVdat.shape[0]
+            if verbose:
+                print("Loading relative RVs from file " + relRVfile)
+        except:
+            if verbose:
+                print("Unable to load relative RV data from file " + relRVfile)
+            self.nrelRV = 0
+        ###########################
 
         try:
             try:

--- a/orvara/orbit.pyx
+++ b/orvara/orbit.pyx
@@ -1182,7 +1182,7 @@ def calcL(Data data, Params par, Model model, bint freemodel=True,
     if not A or not B or not C or not RVzero:
         raise MemoryError()
 
-    for i in range(data.nInst):sau
+    for i in range(data.nInst):
         A[i] = B[i] = C[i] = RVzero[i] = 0
 
     for i in range(data.nRV):

--- a/orvara/orbit_plots.py
+++ b/orvara/orbit_plots.py
@@ -26,7 +26,7 @@ class Orbit:
 
     def __init__(self, OP, step='best', epochs='custom'):
 
-        data = orbit.Data(OP.Hip, OP.HGCAFile, OP.RVfile, OP.relAstfile, verbose=False)
+        data = orbit.Data(OP.Hip, OP.HGCAFile, OP.RVfile, OP.relAstfile, OP.relRVfile, verbose=False)
 
         if isinstance(epochs, list) or isinstance(epochs, np.ndarray):
             data.custom_epochs(epochs, iplanet=OP.iplanet)
@@ -1144,7 +1144,7 @@ class OrbitPlots:
         # The date we want
         JD_predict = self.calendar_to_JD(self.predicted_ep_ast)
 
-        data = orbit.Data(self.Hip, self.HGCAFile, self.RVfile, self.relAstfile, verbose=False)
+        data = orbit.Data(self.Hip, self.HGCAFile, self.RVfile, self.relAstfile, self.relRVfile, verbose=False)
 
         # Solve Kepler's equation in array format given a different
         # eccentricity for each point.  This is the same Newton solver


### PR DESCRIPTION
Hi orvara team --

First, thanks for making this really great code available. I added a feature to the code, that the relative RV between a host star and a companion to be included in the fit, for an upcoming paper I'm co-authoring. In our work we have a system with a low-mass stellar companion, and we've updated the orbital properties of the stellar companion using an orvara fit of the RVs, relative astrometry and Hipp/Gaia astrometry.

Right now this feature is currently only set up for a two-body system; this is all we needed for the paper in question, so I didn't generalize the relative RV function to n companions. I've made sure that the code still passes all the pytest -sv tests, though.

I have a config file for the orbit fitting of our system, that demonstrates how the relative RV works - but I'd prefer not to upload that until the paper is public. Once the paper is out I'm happy to add the config file as one of the examples, if you think that would be useful?

Please do let me know if there are any other problems with the commit, or anything else I should change in the new code.

all the best,

Elisabeth
