### PR TITLE
Fix/astrometry plotting bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+1.0.5 (2021-12-06)
+------------------
+- Fixed a bug in the astrometric orbit plotting.
+
 1.0.4 (2021-05-14)
 ------------------
 - Fixed units bug in periastron time calculation.

--- a/orvara/orbit_plots.py
+++ b/orvara/orbit_plots.py
@@ -405,7 +405,10 @@ class OrbitPlots:
             i += 1
 
             m, b = calc_linear([x, x + _dx], [y, y + _dy])
-
+            if not np.isfinite(m) or not np.isfinite(b):
+                # some ill constrained orbits will have issues plotting predicted epochs.
+                # skip if we find such an epoch.
+                continue
             # plot the predicted epochs data points on the most likely orbit
             ax.scatter(x, y, s=55, facecolors='none', edgecolors='k', zorder=100)
             # calculate the angle between the tangent line and the x-axis

--- a/orvara/orbit_plots.py
+++ b/orvara/orbit_plots.py
@@ -408,6 +408,7 @@ class OrbitPlots:
             if not np.isfinite(m) or not np.isfinite(b):
                 # some ill constrained orbits will have issues plotting predicted epochs.
                 # skip if we find such an epoch.
+                print(f'Failed to plot the predicted epoch {year} in the "Astrometry orbits plot." ')
                 continue
             # plot the predicted epochs data points on the most likely orbit
             ax.scatter(x, y, s=55, facecolors='none', edgecolors='k', zorder=100)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ modules = [Extension("orvara.orbit", source_files, extra_compile_args=['-O3'])]
 
 setup(name='orvara',
       ext_modules=cythonize(modules),
-      version='1.0.4',
+      version='1.0.5',
       python_requires='>=3.5',
       package_dir={'orvara': 'orvara'},
       install_requires=['numpy>=1.13', 'htof>=0.3.4', 'emcee', 'ptemcee',


### PR DESCRIPTION
Fixes a bug that Masayuki encountered when trying to plot an orbit that has an ill-constrained astrometric solution on the sky. The plotting of the predicted epochs failed. 

This PR adds a catch to the predicted epochs plotting so that the code will abort plotting of the epochs (with an error message), instead of crashing out with a hard-to-decipher stack trace.